### PR TITLE
create .bind_or()

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -13,7 +13,7 @@ struct Cli {
 
 fn main() -> Result<(), std::io::Error> {
   let args = Cli::from_args();
-  let tcp_listener = args.port.bind()?;
+  let tcp_listener = args.port.bind_or(8080)?;
   println!("{:?}", tcp_listener);
   Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,9 +65,8 @@ impl Port {
   ///
   /// Useful to create a default socket to listen to if none was passed.
   pub fn bind_or(&self, port: u16) -> std::io::Result<TcpListener> {
-    match self.bind() {
-      Ok(listener) => Ok(listener),
-      Err(_) => TcpListener::bind((self.hostname.as_str(), port)),
-    }
+    self
+      .bind()
+      .or_else(|_| TcpListener::bind((self.hostname.as_str(), port)))
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,4 +59,15 @@ impl Port {
       _ => Err(io::Error::new(io::ErrorKind::Other, "No port supplied.")),
     }
   }
+
+  /// Create a TCP socket by calling to `.bind()`. If it fails, create a socket
+  /// on `port`.
+  ///
+  /// Useful to create a default socket to listen to if none was passed.
+  pub fn bind_or(&self, port: u16) -> std::io::Result<TcpListener> {
+    match self.bind() {
+      Ok(listener) => Ok(listener),
+      Err(_) => TcpListener::bind(("127.0.0.1", port)),
+    }
+  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ impl Port {
   pub fn bind_or(&self, port: u16) -> std::io::Result<TcpListener> {
     match self.bind() {
       Ok(listener) => Ok(listener),
-      Err(_) => TcpListener::bind(("127.0.0.1", port)),
+      Err(_) => TcpListener::bind((self.hostname.as_str(), port)),
     }
   }
 }


### PR DESCRIPTION
Creates a `.bind_or()` method which can be passed a default port to listen to in case none was passed.

Useful for development.

Thanks!

Questions
=========
- This is most useful for development. Should we perhaps have a `#[feature]` gated method instead?
- Ideally we could make use of StructOpts `default = ""` attribute. I'm not sure how to make this configurable so I took this approach instead.